### PR TITLE
fix: resolve build failure and watcher crash on startup

### DIFF
--- a/crates/frankenterm/src/main.rs
+++ b/crates/frankenterm/src/main.rs
@@ -11624,7 +11624,7 @@ async fn distributed_persist_payload(
                             delta.seq,
                         ));
                     }
-                    seq_guard.insert(seq_key, delta.seq);
+                    seq_guard.insert(seq_key.clone(), delta.seq);
                 }
             }
 
@@ -13712,6 +13712,27 @@ async fn run_watcher(
     );
 
     let storage = StorageHandle::with_config(&db_path, storage_config).await?;
+    // Ensure system pane (id=0) exists for lifecycle/system events (FK constraint)
+    {
+        use frankenterm_core::storage::PaneRecord;
+        let now = now_epoch_ms();
+        let system_pane = PaneRecord {
+            pane_id: 0,
+            pane_uuid: Some("00000000-0000-0000-0000-000000000000".to_string()),
+            domain: "system".to_string(),
+            window_id: None,
+            tab_id: None,
+            title: Some("system".to_string()),
+            cwd: None,
+            tty_name: None,
+            first_seen_at: now,
+            last_seen_at: now,
+            observed: false,
+            ignore_reason: Some("system-internal pane for lifecycle events".to_string()),
+            last_decision_at: Some(now),
+        };
+        let _ = storage.upsert_pane(system_pane).await;
+    }
     let lifecycle_event_id =
         emit_recorder_backend_lifecycle_event(&storage, &recorder_startup_selection).await?;
     tracing::info!(db_path = %db_path, "Storage initialized");


### PR DESCRIPTION
## Summary

Two minimal fixes that unblock building and running `ft watch`:

- **Fix 1 — Build failure** (`#30`): `seq_key` (type `(String, u64)`) is moved into `seq_guard.insert()` at line 11627, then reused at lines 11689/11692 in the error-rollback path. Added `.clone()` to prevent `use of moved value` compile error on nightly.

- **Fix 2 — Watcher crash on startup** (`#31`): `emit_recorder_backend_lifecycle_event()` creates an event with `pane_id: 0`, but no row with `pane_id = 0` exists in the `panes` table. Since `events.pane_id` has a FK constraint (`REFERENCES panes(pane_id)`), the INSERT fails with `FOREIGN KEY constraint failed`. Fix: upsert a system pane (id=0, domain="system", observed=false) before emitting the lifecycle event.

## Test plan

- [x] `cargo +nightly build --release -p frankenterm` succeeds (was failing before fix 1)
- [x] `ft watch` starts, initializes storage, pattern engine, IPC server, observation runtime (was crashing immediately before fix 2)
- [x] `ft db check` reports healthy DB with schema v23
- [x] Tested on WSL2 Ubuntu 24.04, rustc nightly, WezTerm 20240203

## Related issues

Fixes #30, Fixes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)