### PR TITLE
Guard ACFS notification workflow on upstream repo

### DIFF
--- a/.github/workflows/notify-acfs.yml
+++ b/.github/workflows/notify-acfs.yml
@@ -29,8 +29,8 @@ concurrency:
 
 jobs:
   notify-acfs:
-    # Only notify on push to main, not PRs
-    if: github.event_name == 'push'
+    # Only notify on upstream pushes to main, not forks or PRs
+    if: github.event_name == 'push' && github.repository == 'Dicklesworthstone/frankenterm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add an upstream-repository guard to the `notify-acfs` job.
- Keep the existing push-only behavior for `Dicklesworthstone/frankenterm`.
- Skip the ACFS repository dispatch on forks, where `ACFS_DISPATCH_TOKEN` is unavailable.

## Orbit-style routing
- Assessment: simple -> hunter
- Rationale: issue #57 is a narrow workflow guard change with low blast radius and no runtime code impact.

## Testing
- `git diff --check -- .github/workflows/notify-acfs.yml`
- Parsed `.github/workflows/notify-acfs.yml` with PyYAML and verified the job `if` expression.
- `actionlint` was not installed in this environment, so that check was skipped.

Closes #57
